### PR TITLE
(GH-10) Target .NET Standard 2.0 and build against Cake 0.26.0

### DIFF
--- a/src/Cake.Figlet/Cake.Figlet.csproj
+++ b/src/Cake.Figlet/Cake.Figlet.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Authors>Phil Scott</Authors>
     <Company />
     <PackageLicenseUrl>https://raw.githubusercontent.com/enkafan/Cake.Figlet/master/LICENSE</PackageLicenseUrl>
@@ -17,6 +17,6 @@
     <EmbeddedResource Include="standard.flf" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.22.2" />
+    <PackageReference Include="Cake.Core" Version="0.26.0" />
   </ItemGroup>
 </Project>

--- a/tests/Cake.Figlet.Tests/Cake.Figlet.Tests.csproj
+++ b/tests/Cake.Figlet.Tests/Cake.Figlet.Tests.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <RuntimeFrameworkVersion>2.0.3</RuntimeFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.22.2" />
+    <PackageReference Include="Cake.Core" Version="0.26.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.1" />
     <PackageReference Include="Shouldly" Version="3.0.0" />
     <PackageReference Include="xunit" Version="2.3.1" />


### PR DESCRIPTION
Target .NET Standard 2.0 and build against Cake 0.26.0

Fixes #10 