### PR TITLE
(GH-18) Add missing [CakeMethodAlias] to Figlet alias with font parameter

### DIFF
--- a/src/Cake.Figlet/FigletAliases.cs
+++ b/src/Cake.Figlet/FigletAliases.cs
@@ -46,6 +46,7 @@ namespace Cake.Figlet
         /// <param name="text">The text to render as ASCII Art.</param>
         /// <param name="fontFile">The Figlet font format file.</param>
         /// <returns>A string containing the ASCII art.</returns>
+        [CakeMethodAlias]
         public static string Figlet(this ICakeContext context, string text, FilePath fontFile)
         {
             var figlet = new Figlet(fontFile.FullPath);


### PR DESCRIPTION
When using the alias with font parameter, the cake build script did not compile due to missing [CakeMethodAlias] attribute on alias method.

Fixes #18 