### PR TITLE
(GH-19) Use netstandard2.0 moniker in NuGet package

### DIFF
--- a/nuspec/nuget/Cake.Figlet.nuspec
+++ b/nuspec/nuget/Cake.Figlet.nuspec
@@ -21,7 +21,7 @@
   </metadata>
 
   <files>
-    <file src="netstandard2.0\Cake.Figlet.dll" target="lib\net45" />
-    <file src="netstandard2.0\Cake.Figlet.pdb" target="lib\net45" />
+    <file src="netstandard2.0\Cake.Figlet.dll" target="lib\netstandard2.0" />
+    <file src="netstandard2.0\Cake.Figlet.pdb" target="lib\netstandard2.0" />
   </files>
 </package>


### PR DESCRIPTION
Use netstandard2.0 moniker in NuGet package

Fixes #19 