### PR TITLE
(GH-22) Remove dependency to Cake.Core from NuGet package

### DIFF
--- a/nuspec/nuget/Cake.Figlet.nuspec
+++ b/nuspec/nuget/Cake.Figlet.nuspec
@@ -15,9 +15,6 @@
     <copyright>Copyright (c) Phil Scott 2016</copyright>
     <releaseNotes>Bumps minimum supported Cake to v0.17</releaseNotes>
     <tags>Cake Script Build Figlet</tags>
-    <dependencies>
-      <dependency id="Cake.Core" version="0.17.0" />
-    </dependencies>
   </metadata>
 
   <files>


### PR DESCRIPTION
Remove dependency to Cake.Core from NuGet package

Fixes #22 
Part of #17 